### PR TITLE
Addition of the driver and supporting example code for the TCA9548a i2c multiplexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Most come with a small example program.
 ## Overview
 
  - vl53l0x: Adds driver for the VL53L0X TOF Distance sensor ([Adapted From here](https://github.com/bitbank2/VL53L0X))
+ - tca9548a: Adds driver for the TCA9548a I2C multiplexer to resolve the address conflict between the TCS3472 AND VL53L0X
  - tcs3472: Adds driver for the TCS3472 Colour Sensor
  - PULSECOUNTER: Add an example usages for this existing library.
  - MQTT_UART: Demonstrates interactions between PYNQ and 5EID0 UART<>MQTT bridge.

--- a/libraries/TCA9548a/TCA9548A.c
+++ b/libraries/TCA9548a/TCA9548A.c
@@ -1,0 +1,50 @@
+// File: TCA9548A.c
+/*
+ *  TU/e 5EID0::LIBPYNQ Driver for TCA9548A I2C Multiplexer
+ *
+ *  Written By: Meltedgyro_FPV
+ *  Syntax based on libpynq extended by Walthzer
+ */
+
+#include "TCA9548A.h"
+#include <libpynq.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/*
+ * @brief Low-level write of the 8-bit control register (selects channels).
+ */
+static int write_control(iic_index_t iic, uint8_t control)
+{
+    /* The TCA9548A has its control register at pointer 0x00 */
+    return iic_write_register(iic, TCA9548A_I2C_ADDR, 0x00, &control, 1);
+}
+
+int tca9548a_init(iic_index_t iic, tca9548a *mux)
+{
+    if (!mux) return 1;
+    mux->iic_index = iic;
+    mux->current_channel = 0xFF;  /* no channel selected */
+    /* Disable all downstream channels */
+    return write_control(iic, 0x00);
+}
+
+int tca9548a_destroy(tca9548a *mux)
+{
+    if (!mux) return 1;
+    mux->current_channel = 0xFF;
+    /* Again disable everything */
+    return write_control(mux->iic_index, 0x00);
+}
+
+int tca9548a_select_channel(tca9548a *mux, uint8_t channel)
+{
+    if (!mux || channel >= TCA9548A_CHANNEL_COUNT)
+        return 1;
+    uint8_t control = (1u << channel);
+    int err = write_control(mux->iic_index, control);
+    if (!err) {
+        mux->current_channel = channel;
+    }
+    return err;
+}

--- a/libraries/TCA9548a/TCA9548A.h
+++ b/libraries/TCA9548a/TCA9548A.h
@@ -1,0 +1,55 @@
+// File: TCA9548A.h
+/*
+ *  TU/e 5EID0::LIBPYNQ Driver for TCA9548A I2C Multiplexer
+ *
+ *  Written By: Meltedgyro_FPV
+ *  Syntax based on libpynq extended by Walthzer
+ *
+ *  Licensed under GPLv3 or later
+ */
+
+#ifndef _TCA9548A_H_
+#define _TCA9548A_H_
+
+#include <stdint.h>
+#include <libpynq.h>
+
+#define TCA9548A_I2C_ADDR       0x70    /**< Default I²C address */
+#define TCA9548A_CHANNEL_COUNT  8       /**< Number of downstream channels */
+
+/**
+ * @brief Handle for a TCA9548A multiplexer instance.
+ */
+typedef struct _tca9548a_mux_ {
+    iic_index_t iic_index;    /**< Which I²C bus to talk to the mux on */
+    uint8_t     current_channel; /**< Last‐selected channel (0–7), 0xFF if none */
+} tca9548a;
+
+/**
+ * @brief Initialize the TCA9548A multiplexer.
+ *        Disables all channels on startup.
+ *
+ * @param iic   I²C interface index (IIC0, IIC1, …)
+ * @param mux   Pointer to the mux handle (must not be NULL)
+ * @return 0 on success, non‐zero on error
+ */
+extern int tca9548a_init(iic_index_t iic, tca9548a *mux);
+
+/**
+ * @brief Tear down the multiplexer, disabling all channels.
+ *
+ * @param mux   Pointer to a previously inited mux handle
+ * @return 0 on success, non‐zero on error
+ */
+extern int tca9548a_destroy(tca9548a *mux);
+
+/**
+ * @brief Select exactly one downstream channel on the mux.
+ *
+ * @param mux      Pointer to the mux handle
+ * @param channel  Which channel to enable (0–7)
+ * @return 0 on success, non‐zero if channel ≥8 or on I²C error
+ */
+extern int tca9548a_select_channel(tca9548a *mux, uint8_t channel);
+
+#endif // _TCA9548A_H_

--- a/libraries/TCA9548a/main.c
+++ b/libraries/TCA9548a/main.c
@@ -1,0 +1,57 @@
+/*
+ * tca9548a_example.c
+ *
+ * Minimal example demonstrating how to use the TCA9548A I2C multiplexer
+ * with the libpynq platform. This code shows how to initialize the I2C
+ * interface, configure the multiplexer, and select different channels to
+ * communicate with multiple I2C devices on the same bus.
+ *
+ * Author: Meltedgyro_FPV
+ * License: GNU General Public License v3.0 or later
+ */
+
+#include <stdio.h>
+#include <iic.h>
+#include <switchbox.h>
+#include "TCA9548A.h"
+
+int main(void) {
+    // === Step 1: Connect physical I2C pins to IIC0 hardware block ===
+    switchbox_set_pin(IO_AR_SCL, SWB_IIC0_SCL); // Map SCL line to IIC0 controller
+    switchbox_set_pin(IO_AR_SDA, SWB_IIC0_SDA); // Map SDA line to IIC0 controller
+
+    // === Step 2: Initialize I2C controller (IIC0) ===
+    iic_init(IIC0);
+
+    // === Step 3: Declare and initialize the multiplexer handle ===
+    tca9548a mux;
+    if (tca9548a_init(IIC0, &mux)) {
+        fprintf(stderr, "Failed to initialize TCA9548A multiplexer\n");
+        iic_destroy(IIC0);
+        return 1;
+    }
+
+    // === Step 4: Select a specific channel on the multiplexer ===
+    // Channel 0 might be used for a color sensor or another I2C device
+    if (tca9548a_select_channel(&mux, 0)) {
+        fprintf(stderr, "Failed to select channel 0 on multiplexer\n");
+    } else {
+        printf("✔ Channel 0 selected — ready to talk to device on channel 0.\n");
+        // Here, you would call the device driver functions for your sensor on channel 0
+    }
+
+    // Now switch to another device, e.g., on channel 1
+    if (tca9548a_select_channel(&mux, 1)) {
+        fprintf(stderr, "Failed to select channel 1 on multiplexer\n");
+    } else {
+        printf("✔ Channel 1 selected — ready to talk to device on channel 1.\n");
+        // Here, you would talk to a different sensor/device connected to channel 1
+    }
+
+    // === Step 5: Cleanup ===
+    // Always clean up hardware interfaces before exiting
+    tca9548a_destroy(&mux);    // Free internal resources of multiplexer
+    iic_destroy(IIC0);         // Shutdown I2C interface
+
+    return 0;
+}


### PR DESCRIPTION
Adds TCA9548A I2C multiplexer to separate the TCS3472 and VL53L0X sensors onto different channels, resolving the I2C address conflict on the PYNQ platform.
